### PR TITLE
Add backend controller tests placeholders

### DIFF
--- a/backend/src/test/java/com/MC_656/mobility/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/MC_656/mobility/controller/AuthControllerTest.java
@@ -1,0 +1,37 @@
+package com.MC_656.mobility.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthControllerTest {
+
+    @Test
+    @DisplayName("Should login successfully with valid credentials")
+    void loginWithValidCredentials() {
+        // TODO: Implement actual test logic when AuthController is available
+        assertTrue(true, "This test will be implemented when AuthController is available");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "invalid@example.com, password123",
+        "user@example.com, wrongpass"
+    })
+    @DisplayName("Should reject login with invalid credentials")
+    void rejectLoginWithInvalidCredentials(String email, String password) {
+        // TODO: Implement actual test logic when AuthController is available
+        assertTrue(true, "This test will be implemented when AuthController is available");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "thisPasswordIsWayTooLongToBeAcceptedByTheSystemBecauseItExceedsTheMaximumAllowedLength"})
+    @DisplayName("Should enforce password boundary conditions")
+    void passwordBoundaryConditions(String password) {
+        // TODO: Implement actual test logic when AuthController is available
+        assertTrue(true, "This test will be implemented when AuthController is available");
+    }
+}

--- a/backend/src/test/java/com/MC_656/mobility/controller/RentalControllerTest.java
+++ b/backend/src/test/java/com/MC_656/mobility/controller/RentalControllerTest.java
@@ -1,0 +1,32 @@
+package com.MC_656.mobility.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RentalControllerTest {
+
+    @Test
+    @DisplayName("Should start rental with existing vehicle")
+    void startRentalWithExistingVehicle() {
+        // TODO: Implement actual test logic when RentalController is available
+        assertTrue(true, "This test will be implemented when RentalController is available");
+    }
+
+    @Test
+    @DisplayName("Should reject rental with non-existing vehicle")
+    void rejectRentalWithNonExistingVehicle() {
+        // TODO: Implement actual test logic when RentalController is available
+        assertTrue(true, "This test will be implemented when RentalController is available");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    @DisplayName("Should enforce vehicle id boundary conditions")
+    void vehicleIdBoundaryConditions(int vehicleId) {
+        // TODO: Implement actual test logic when RentalController is available
+        assertTrue(true, "This test will be implemented when RentalController is available");
+    }
+}

--- a/backend/src/test/java/com/MC_656/mobility/controller/VehicleControllerTest.java
+++ b/backend/src/test/java/com/MC_656/mobility/controller/VehicleControllerTest.java
@@ -1,0 +1,35 @@
+package com.MC_656.mobility.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VehicleControllerTest {
+
+    @Test
+    @DisplayName("Should create vehicle with valid data")
+    void createVehicleWithValidData() {
+        // TODO: Implement actual test logic when VehicleController is available
+        assertTrue(true, "This test will be implemented when VehicleController is available");
+    }
+
+    @Test
+    @DisplayName("Should reject vehicle creation with duplicate plate")
+    void rejectVehicleCreationWithDuplicatePlate() {
+        // TODO: Implement actual test logic when VehicleController is available
+        assertTrue(true, "This test will be implemented when VehicleController is available");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "1990, 2050",
+        "1885, 2050" // below minimum year
+    })
+    @DisplayName("Should validate vehicle manufacturing year limits")
+    void vehicleYearBoundaryConditions(int year, int currentYear) {
+        // TODO: Implement actual test logic when VehicleController is available
+        assertTrue(true, "This test will be implemented when VehicleController is available");
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthControllerTest for login scenarios
- add VehicleControllerTest for vehicle creation scenarios
- add RentalControllerTest for rental start scenarios

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6869936155a083218fe4f9e301311ff6